### PR TITLE
Add state_class=measurement to water_flow sensor

### DIFF
--- a/custom_components/hass_pontos/device_config/conf_neosoft.py
+++ b/custom_components/hass_pontos/device_config/conf_neosoft.py
@@ -111,6 +111,7 @@ SENSOR_DETAILS = {
         "unit": "L/h",
         "device_class": SensorDeviceClass.VOLUME_FLOW_RATE,
         "scale": 1,
+        "state_class": SensorStateClass.MEASUREMENT,
     },
     "current_consumption": {
         "name": "Current water consumption",

--- a/custom_components/hass_pontos/device_config/conf_safetech.py
+++ b/custom_components/hass_pontos/device_config/conf_safetech.py
@@ -85,6 +85,7 @@ SENSOR_DETAILS = {
         "unit": "L/h",
         "device_class": SensorDeviceClass.VOLUME_FLOW_RATE,
         "scale": 1,
+        "state_class": SensorStateClass.MEASUREMENT,
     },
     "no_pulse_time": {
         "name": "Time since last turbine pulse",

--- a/custom_components/hass_pontos/device_config/conf_safetech_v4.py
+++ b/custom_components/hass_pontos/device_config/conf_safetech_v4.py
@@ -66,6 +66,7 @@ SENSOR_DETAILS = {
         "unit": "L/h",
         "device_class": SensorDeviceClass.VOLUME_FLOW_RATE,
         "scale": 1,
+        "state_class": SensorStateClass.MEASUREMENT,
     },
     "water_temperature": {
         "name": "Water temperature",

--- a/custom_components/hass_pontos/device_config/conf_trio.py
+++ b/custom_components/hass_pontos/device_config/conf_trio.py
@@ -69,6 +69,7 @@ SENSOR_DETAILS = {
         "unit": "L/h",
         "device_class": SensorDeviceClass.VOLUME_FLOW_RATE,
         "scale": 1,
+        "state_class": SensorStateClass.MEASUREMENT,
     },
     "no_pulse_time": {
         "name": "Time since last turbine pulse",


### PR DESCRIPTION
## Problem

The `water_flow` sensor (instantaneous flow rate in L/h, endpoint `getFLO`) does not appear in the Home Assistant **Energy dashboard** under "Water consumption → Water flow rate". The dropdown filters by entities that report long-term statistics with a `volume_flow_rate` unit, and only entities with a `state_class` get recorded into long-term statistics.

Verified on a SafeTech Connect (V3.56) with this integration: `sensor.<...>_water_flow` has `device_class=volume_flow_rate` and unit `L/h`, but `state_class` is `None`, so it never reaches the statistics table and is not selectable as flow rate.

For context, `water_consumption` already has `state_class=total_increasing` (added in #50) and works correctly in the Energy dashboard's water consumption slot.

## Fix

Add `"state_class": SensorStateClass.MEASUREMENT` to the `water_flow` entry. `MEASUREMENT` is the correct class for an instantaneous rate (vs. `TOTAL_INCREASING` for the cumulative counter).

Applied to all device configs that define `water_flow`:

- `conf_safetech.py`
- `conf_safetech_v4.py`
- `conf_trio.py`
- `conf_neosoft.py`

`conf_pontos.py` does not define `water_flow` and is left unchanged.

## Verification

Locally reproduced the missing-flow-rate behavior, then mirrored the same data via a manual Template sensor with `device_class=volume_flow_rate` + `state_class=measurement` + unit `L/min` — it shows up in the Energy dashboard's flow rate dropdown and accumulates statistics as expected. Applying the same `state_class` to the integration's own sensor produces the same result without needing a helper.

`SensorStateClass` is already imported in all four files.

## Out of scope

`water_pressure` and `water_temperature` are also missing `state_class` (would be `MEASUREMENT`). Not changing them in this PR to keep it focused on the Energy dashboard issue; happy to open a follow-up if you want them aligned too.
